### PR TITLE
Display details box only when fetched from remote service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_Store
+node_modules

--- a/core/tmdb-service.js
+++ b/core/tmdb-service.js
@@ -4,6 +4,7 @@
  */
 var Montage = require("montage/core/core").Montage;
 var RangeController = require("montage/core/range-controller").RangeController;
+var Promise = require("montage/core/promise").Promise;
 
 var CategoryController = require("./category-controller").CategoryController;
 var sharedTransport = require("./jsonp-transport").shared;
@@ -38,11 +39,22 @@ exports.TmdbService = Montage.specialize(/** @lends TmdbService# */ {
             self.topDvdRentals = new CategoryController("Top Rated", "rentals");
             self.inTheaters = new CategoryController("Popular", "in_theaters");
 
+            self.latestBoxOffice.contentController.addRangeAtPathChangeListener("selection", this, "handleMovieSelectionChange");
+            self.upcoming.contentController.addRangeAtPathChangeListener("selection", this, "handleMovieSelectionChange");
+            self.topDvdRentals.contentController.addRangeAtPathChangeListener("selection", this, "handleMovieSelectionChange");
+            self.inTheaters.contentController.addRangeAtPathChangeListener("selection", this, "handleMovieSelectionChange");
+
             var boxOfficePromise = this.loadLatestBoxOfficeMovies()
             .then(function (latestBoxOffice) {
                 self.latestBoxOffice.contentController.content = latestBoxOffice;
                 self.categories.content.push(self.latestBoxOffice, self.inTheaters, self.upcoming, self.topDvdRentals);
                 self.categories.select(self.latestBoxOffice);
+                return latestBoxOffice;
+            })
+            .then(function(latestBoxOffice) {
+                if (latestBoxOffice && latestBoxOffice.length > 0) {
+                    self.preloadMovie(latestBoxOffice[0]);
+                }
             });
             // we fork the promise chain to expose the resolution of the first list.
             boxOfficePromise
@@ -58,6 +70,22 @@ exports.TmdbService = Montage.specialize(/** @lends TmdbService# */ {
                 self.upcoming.contentController.content = upcomingMovies;
                 self.topDvdRentals.contentController.content = topDvdRentals;
                 self.inTheaters.contentController.content = inTheaters;
+                return [
+                    upcomingMovies,
+                    topDvdRentals,
+                    inTheaters
+                ];
+            })
+            .spread(function (upcomingMovies, topDvdRentals, inTheaters) {
+                if (upcomingMovies && upcomingMovies.length > 0) {
+                    self.preloadMovie(upcomingMovies[0]);
+                }
+                if (topDvdRentals && topDvdRentals.length > 0) {
+                    self.preloadMovie(topDvdRentals[0]);
+                }
+                if (inTheaters && inTheaters.length > 0) {
+                    self.preloadMovie(inTheaters[0]);
+                }
             })
             .done();
 
@@ -142,8 +170,65 @@ exports.TmdbService = Montage.specialize(/** @lends TmdbService# */ {
                 return response;
             });
         }
-    }
+    },
 
+    preloadMovie: {
+        value: function(oldMovie) {
+            if (oldMovie && !oldMovie.loaded) {
+                var self = this,
+                    runtime;
+                oldMovie.loaded = true;
+                return this.loadMovie(oldMovie)
+                    .then(function(movie) {
+                        runtime = movie.runtime;
+                        return self.loadReleases(movie);
+                    })
+                    .then(function(releases) {
+                        var rating = releases.countries[0].certification;
+
+                        if (rating.length === 0) {
+                            rating = "none";
+                        }
+                        for (var i = 0, categoriesLength = self.categories.content.length; i < categoriesLength; i++) {
+                            var category = self.categories.content[i];
+                            for (var j = 0, moviesLength = category.contentController.content.length; j < moviesLength; j++) {
+                                var storedMovie = category.contentController.content[j];
+                                if (storedMovie.id === oldMovie.id) {
+                                    category.contentController.content[j].mpaaRating = rating;
+                                    category.contentController.content[j].runtime = runtime;
+                                    category.contentController.content[j].loaded = true;
+                                }
+                            }
+                        }
+                        console.log('preloaded', oldMovie.title);
+                    });
+            } else {
+                return Promise.resolve();
+            }
+        }
+    },
+
+    handleMovieSelectionChange: {
+        value: function() {
+            var self = this,
+                selectedCategory = this.categories.selection.one();
+            if (selectedCategory && selectedCategory.contentController && selectedCategory.contentController.selection) {
+                for (var i = 0, moviesLength = selectedCategory.contentController.content.length; i < moviesLength; i++) {
+                    var currentMovie = selectedCategory.contentController.content[i];
+                    if (currentMovie === selectedCategory.contentController.selection[0]) {
+                        this.preloadMovie(selectedCategory.contentController.content[i+1])
+                            .then(function() {
+                                self.preloadMovie(selectedCategory.contentController.content[i+2]);
+                            })
+                            .then(function() {
+                                self.preloadMovie(selectedCategory.contentController.content[i+3]);
+                            });
+                        break;
+                    }
+                }
+            }
+        }
+    }
 });
 
 exports.shared = new exports.TmdbService();

--- a/ui/details.reel/details.css
+++ b/ui/details.reel/details.css
@@ -248,3 +248,10 @@
     
 }
 
+.Details.visible {
+    opacity: 1;
+    -webkit-transition: opacity .35s, -webkit-transform .35s;
+    -moz-transition: opacity .35s, -moz-transform .35s;
+    -ms-transition: opacity .35s, -ms-transform .35s;
+    transition: opacity .35s, transform .35s;
+}

--- a/ui/details.reel/details.html
+++ b/ui/details.reel/details.html
@@ -9,6 +9,9 @@
             "properties": {
                 "element": {"#": "owner"},
                 "popularityIcon": {"#": "popularityIcon"}
+            },
+            "bindings": {
+                "classList.has('visible')": {"<-": "@owner.isVisible"}
             }
         },
         "audienceScore": {

--- a/ui/details.reel/details.js
+++ b/ui/details.reel/details.js
@@ -10,6 +10,9 @@ exports.Details = Component.specialize({
         }
     },
 
+    isVisible: {
+        value: null
+    },
 
     _movie: {
         value: null
@@ -19,11 +22,13 @@ exports.Details = Component.specialize({
         set: function (val) {
             var self = this;
             this._movie = val;
-            if(val != null) {
+            this.isVisible = false;
+            if(val != null && !val.loaded) {
                 sharedTmdbService.loadMovie(val)
                 .then(function (movie) {
                     self.dispatchBeforeOwnPropertyChange("movie", self._movie);
                     self._movie = movie;
+                    val.runtime = movie.runtime;
                     self.dispatchOwnPropertyChange("movie", self._movie);
                     return movie;
                 })
@@ -36,9 +41,13 @@ exports.Details = Component.specialize({
                     if (rating.length === 0) {
                         rating = "none";
                     }
-                    self._movie.mpaaRating = rating;
+                    val.mpaaRating = self._movie.mpaaRating = rating;
+                    val.loaded = true;
+                    self.isVisible = true;
                 })
                 .done();
+            } else {
+                this.isVisible = true;
             }
             this.needsDraw = true;
         },

--- a/ui/main.reel/main.css
+++ b/ui/main.reel/main.css
@@ -43,6 +43,7 @@
         margin-top: -530px;
     }
     .Main-details {
+        opacity: 0;
         position: fixed;
         z-index: 3;
         bottom: 10px;
@@ -54,10 +55,6 @@
         -moz-transform: translate3d(0,148px,0);
         -ms-transform: translate3d(0,148px,0);
         transform: translate3d(0,148px,0);
-        -webkit-transition: opacity .35s, -webkit-transform .35s;
-        -moz-transition: opacity .35s, -moz-transform .35s;
-        -ms-transition: opacity .35s, -ms-transform .35s;
-        transition: opacity .35s, transform .35s;
     }
     .Main-details.expanded {
         -webkit-transform: translate3d(0,0,0);
@@ -90,6 +87,7 @@
         margin-top: -525px;
     }
     .Main-details {
+        opacity: 0;
         position: fixed;
         z-index: 3;
         top: 50%;
@@ -98,10 +96,6 @@
         margin-left: -250px;
         margin-top: 138px;
         height: 203px;
-        -webkit-transition: opacity .35s, -webkit-transform .35s;
-        -moz-transition: opacity .35s, -moz-transform .35s;
-        -ms-transition: opacity .35s, -ms-transform .35s;
-        transition: opacity .35s, transform .35s;
     }
     .Main-details .title:before {
         display: none;
@@ -124,6 +118,7 @@
         margin-top: -525px;
     }
     .Main-details {
+        opacity: 0;
         position: fixed;
         z-index: 1;
         bottom: 64px;
@@ -135,10 +130,6 @@
         -moz-transform: translate3d(0,177px,0);
         -ms-transform: translate3d(0,177px,0);
         transform: translate3d(0,177px,0);
-        -webkit-transition: opacity .35s, -webkit-transform .35s;
-        -moz-transition: opacity .35s, -moz-transform .35s;
-        -ms-transition: opacity .35s, -ms-transform .35s;
-        transition: opacity .35s, transform .35s;
     }
     .Main-details.expanded {
         -webkit-transform: translate3d(0,0,0);
@@ -167,6 +158,7 @@
         width: auto;
     }
     .Main-details {
+        opacity: 0;
         position: absolute;
         bottom: 10px;
         left: 10px;
@@ -179,10 +171,6 @@
         -moz-transform: translate3d(0,148px,0);
         -ms-transform: translate3d(0,148px,0);
         transform: translate3d(0,148px,0);
-        -webkit-transition: opacity .35s, -webkit-transform .35s;
-        -moz-transition: opacity .35s, -moz-transform .35s;
-        -ms-transition: opacity .35s, -ms-transform .35s;
-        transition: opacity .35s, transform .35s;
     }
     .Main-details.expanded {
         -webkit-transform: translate3d(0,0,0);

--- a/ui/main.reel/main.html
+++ b/ui/main.reel/main.html
@@ -17,7 +17,7 @@
                 "element": {"#": "categories"}
             },
             "bindings": {
-                "categories": {"<-": "@owner.rottenTomato.categories"}
+                "categories": {"<-": "@owner.moviesService.categories"}
             }
         },
         "details": {
@@ -36,7 +36,7 @@
                 "movieDetails": {"@": "details"}
             },
             "bindings": {
-                "categoryContentController": {"<-": "@owner.rottenTomato.categories.selection.one().contentController"}
+                "categoryContentController": {"<-": "@owner.moviesService.categories.selection.one().contentController"}
             }
         },
         "player": {

--- a/ui/main.reel/main.js
+++ b/ui/main.reel/main.js
@@ -1,6 +1,6 @@
 
 var Component = require("montage/ui/component").Component,
-    sharedRottenTomatoService = require("core/tmdb-service").shared,
+    sharedMoviesService = require("core/tmdb-service").shared,
     sharedYoutubeService = require("core/youtube-service").shared;
 
 //TODO use details in toggle buttons
@@ -12,12 +12,12 @@ exports.Main = Component.specialize({
             this.application.addEventListener( "openTrailer", this, false);
 
             this.canDrawGate.setField("moviesLoaded", false);
-            this._initialDataLoad = this.rottenTomato.load();
+            this._initialDataLoad = this.moviesService.load();
         }
     },
 
-    rottenTomato: {
-        value: sharedRottenTomatoService
+    moviesService: {
+        value: sharedMoviesService
     },
 
     _initialDataLoad: {

--- a/ui/main.reel/main.meta
+++ b/ui/main.reel/main.meta
@@ -13,7 +13,7 @@
   "blueprint_unnamed_rottenTomato": {
     "prototype": "montage/core/meta/property-blueprint",
     "properties": {
-      "name": "rottenTomato",
+      "name": "moviesService",
       "blueprint": {"@": "root"},
       "valueType": "object"
     }


### PR DESCRIPTION
To avoid flickering of rating and duration fields, it waits for the movie details to be fully available before displaying the details box.
It pre-fetches the data from the remote service to be able to display the details box as soon as possible.